### PR TITLE
fix(review): top 3 fixes from read-only review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ No build step. CommonJS throughout, no transpilation.
 
 ```bash
 cd /path/to/project
-sextant init         # creates .planning/intel/, registers sextant MCP server in .mcp.json
+sextant init         # creates .planning/intel/, registers MCP server in .mcp.json, wires Claude Code hooks (SessionStart + UserPromptSubmit) in .claude/settings.json
 sextant scan --force # indexes files, builds dependency graph
 ```
 

--- a/commands/hook-refresh.js
+++ b/commands/hook-refresh.js
@@ -112,7 +112,17 @@ async function run() {
   // status-line path triggers is fully flushed before Node exits.
   const statusLinePromise = writeStatusLine(root);
 
-  const prompt = data.prompt || data.message || "";
+  const rawPrompt = data.prompt || data.message || "";
+
+  // WHY: cap prompt length before classification + retrieval. Classifier
+  // tokenization and downstream rg/zoekt queries scan the whole string;
+  // a runaway prompt (paste of a giant log, etc.) would stretch latency
+  // well past the hook budget. 8 KB is more than any real coding
+  // question; trim from the start so the most recent text wins.
+  const MAX_PROMPT_CHARS = 8192;
+  const prompt = rawPrompt.length > MAX_PROMPT_CHARS
+    ? rawPrompt.slice(rawPrompt.length - MAX_PROMPT_CHARS)
+    : rawPrompt;
 
   // 1. Classify
   let classification;

--- a/commands/init.js
+++ b/commands/init.js
@@ -19,14 +19,22 @@ function ensureMcpJson(root) {
   if (existing?.mcpServers?.sextant) return { path: p, alreadyRegistered: true };
   existing.mcpServers = existing.mcpServers || {};
   existing.mcpServers.sextant = SEXTANT_MCP_ENTRY;
-  fs.writeFileSync(p, JSON.stringify(existing, null, 2) + "\n");
+  // WHY: tmp+rename so a crash mid-write can't truncate .mcp.json and
+  // wipe other MCP servers the user has registered.  Mirrors the atomic
+  // write in lib/intel.js:ensureClaudeSettingsUnlocked.
+  const tmp = p + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify(existing, null, 2) + "\n");
+  fs.renameSync(tmp, p);
   return { path: p, alreadyRegistered: false };
 }
 
-// WHY: init was silent — users had no feedback on what it did.  Report the
-// created files and explicitly surface the "hooks not wired" case, which is
-// the #1 source of confusion (README claimed init wires hooks; CLAUDE.md
-// correctly says it doesn't).  Honest output beats mismatched docs.
+// WHY: init was silent — users had no feedback on what it did.  intel.init()
+// (called by run() below) wires SessionStart and UserPromptSubmit hooks
+// into .claude/settings.json — creating the file if it doesn't exist,
+// otherwise merging in.  Report the result so users can see what changed
+// and so the rare failure modes (unparseable existing settings.json,
+// permission errors) surface as "hooks not wired" rather than silently
+// missing the integration.
 function hasSextantHook(settings, event) {
   const events = settings?.hooks?.[event];
   if (!Array.isArray(events)) return false;

--- a/lib/rg.js
+++ b/lib/rg.js
@@ -195,7 +195,11 @@ async function search(root, q, opts = {}) {
   // keeps the highest-scored hits per file rather than the first ones.
   const srcArgs = buildBaseArgs(mode);
   for (const g of SOURCE_GLOBS) srcArgs.push("--glob", g);
-  srcArgs.push(q, ".");
+  // WHY: "--" terminates option parsing in rg. Without it, a query starting
+  // with "-" (e.g. "-foo") is interpreted as an unknown flag and rg exits
+  // non-zero before searching. The separator forces rg to treat q as a
+  // positional pattern even if it begins with a dash.
+  srcArgs.push("--", q, ".");
 
   const srcHits = await collectHits(root, srcArgs, maxHits);
 
@@ -205,7 +209,7 @@ async function search(root, q, opts = {}) {
   if (remaining > 0) {
     const otherArgs = buildBaseArgs(mode);
     for (const g of SOURCE_GLOBS) otherArgs.push("--glob", `!${g}`);
-    otherArgs.push(q, ".");
+    otherArgs.push("--", q, ".");
     otherHits = await collectHits(root, otherArgs, remaining);
   }
 
@@ -236,7 +240,8 @@ async function searchInFiles(root, q, filePaths, opts = {}) {
 
   const args = ["--json", "-n", "--smart-case"];
   if (mode === "literal") args.push("-F");
-  args.push(q);
+  // WHY: "--" prevents leading-dash queries from being parsed as options.
+  args.push("--", q);
   for (const f of filePaths) args.push(f);
 
   const hits = await collectHits(root, args, opts.maxHits ?? 20);

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -91,6 +91,23 @@ const TOOLS = [
 
 // --- Tool handlers ------------------------------------------------------
 
+// WHY: bound query length so a runaway agent or pathological prompt can't
+// fan out into multi-second rg invocations. 2 KB is well above any real
+// symbol/phrase search and well below anything that would exercise rg's
+// internal limits.
+const MAX_QUERY_CHARS = 2048;
+
+function normalizeQuery(query) {
+  if (!query || typeof query !== "string" || !query.trim()) {
+    throw new Error("query parameter is required");
+  }
+  const trimmed = query.trim();
+  if (trimmed.length > MAX_QUERY_CHARS) {
+    throw new Error(`query too long: ${trimmed.length} chars (max ${MAX_QUERY_CHARS})`);
+  }
+  return trimmed;
+}
+
 let _root = null;
 let _initialized = false;
 
@@ -105,14 +122,11 @@ async function ensureInit() {
 
 async function handleSearch(params) {
   await ensureInit();
-  const query = params.query;
-  if (!query || typeof query !== "string" || !query.trim()) {
-    throw new Error("query parameter is required");
-  }
+  const query = normalizeQuery(params.query);
   const limit = Number.isFinite(params.limit) ? params.limit : 10;
   const contextLines = Number.isFinite(params.context_lines) ? params.context_lines : 1;
 
-  const result = await retrieve(_root, query.trim(), {
+  const result = await retrieve(_root, query, {
     maxHits: limit * 5,
     maxSeedFiles: limit,
     hitsPerFileCap: 3,

--- a/test/freshness-gate.test.js
+++ b/test/freshness-gate.test.js
@@ -26,6 +26,30 @@ function gitInit(dir) {
   execSync('git config user.name "Test"', { cwd: dir });
   execSync("git config commit.gpgsign false", { cwd: dir });
 }
+
+// WHY: applyFreshnessGate -> enqueueRescan spawns `sextant scan` on PATH.
+// In CI / fresh clones (no `npm link`), the spawn raises ENOENT
+// asynchronously after the test has returned, which node:test reports as
+// an unhandled error.  A no-op shim makes the spawn succeed so the gate's
+// rescanState lands as "requested" and the test exercises only the body
+// content it actually asserts on.
+let _shimDir = null;
+let _origPath = null;
+function installSextantShim() {
+  _shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-shim-"));
+  const shim = path.join(_shimDir, "sextant");
+  fs.writeFileSync(shim, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  _origPath = process.env.PATH;
+  process.env.PATH = `${_shimDir}${path.delimiter}${_origPath || ""}`;
+}
+function removeSextantShim() {
+  if (_origPath != null) process.env.PATH = _origPath;
+  if (_shimDir) {
+    try { fs.rmSync(_shimDir, { recursive: true, force: true }); } catch {}
+  }
+  _shimDir = null;
+  _origPath = null;
+}
 function gitCommitFile(dir, name, content) {
   fs.writeFileSync(path.join(dir, name), content);
   execSync(`git add ${name}`, { cwd: dir });
@@ -96,6 +120,7 @@ describe("applyFreshnessGate: fresh path passes through rawSummary", () => {
 describe("applyFreshnessGate: stale path strips structural fields", () => {
   let dir;
   before(async () => {
+    installSextantShim();
     dir = makeRepo("stale");
     const db = await graph.loadDb(dir);
     freshness.recordScanState(db, dir);
@@ -104,9 +129,8 @@ describe("applyFreshnessGate: stale path strips structural fields", () => {
     gitCommitFile(dir, "newfile.js", "module.exports = 2;\n");
   });
   after(() => {
-    // The gate triggers a background spawn; give it a chance to fail-fast
-    // (most CI environments won't have `sextant` on PATH) before we rmSync.
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    removeSextantShim();
   });
 
   it("returns a minimal body containing no structural numbers", async () => {

--- a/test/freshness.test.js
+++ b/test/freshness.test.js
@@ -25,6 +25,31 @@ function gitInit(dir) {
   execSync("git config commit.gpgsign false", { cwd: dir });
 }
 
+// WHY: enqueueRescan spawns `sextant scan` via PATH lookup.  In CI / fresh
+// clones (no `npm link`), there is no `sextant` on PATH and the spawn
+// raises ENOENT *asynchronously* — after the test that triggered it has
+// returned — which node:test reports as an unhandled async error and fails
+// the whole test.  Drop a no-op shim onto PATH for the duration of the
+// suite so the spawn succeeds and the test only exercises the marker
+// logic it actually cares about.
+let _shimDir = null;
+let _origPath = null;
+function installSextantShim() {
+  _shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-shim-"));
+  const shim = path.join(_shimDir, "sextant");
+  fs.writeFileSync(shim, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  _origPath = process.env.PATH;
+  process.env.PATH = `${_shimDir}${path.delimiter}${_origPath || ""}`;
+}
+function removeSextantShim() {
+  if (_origPath != null) process.env.PATH = _origPath;
+  if (_shimDir) {
+    try { fs.rmSync(_shimDir, { recursive: true, force: true }); } catch {}
+  }
+  _shimDir = null;
+  _origPath = null;
+}
+
 function gitCommitFile(dir, name, content, message = "commit") {
   fs.writeFileSync(path.join(dir, name), content);
   execSync(`git add ${name}`, { cwd: dir });
@@ -152,13 +177,17 @@ describe("freshness.checkFreshness: scanner_version mismatch → stale", () => {
 
 describe("freshness.enqueueRescan: atomic single-flight", () => {
   let dir;
-  before(() => { dir = makeRepo("rescan"); });
+  before(() => {
+    installSextantShim();
+    dir = makeRepo("rescan");
+  });
   after(() => {
     if (dir) {
       // Best-effort: clean any spawned scan output before tearing down.
       try { fs.rmSync(path.join(dir, ".planning"), { recursive: true, force: true }); } catch {}
       fs.rmSync(dir, { recursive: true, force: true });
     }
+    removeSextantShim();
   });
 
   it("first call requests, second call sees pending", () => {


### PR DESCRIPTION
## Summary

Implements the top 3 fixes from the read-only Sextant review:

1. **rg/MCP query injection (lib/rg.js)** — insert a literal `--` separator immediately before the user-controlled query in all three rg argv push sites (`search` phase 1 source-files, `search` phase 2 non-source, `searchInFiles`). A query starting with `-` was previously interpreted by rg as an unknown flag and aborted the search. With `--`, rg always treats the next token as the positional pattern. Paired with input-length validation:
   - **mcp/server.js**: `normalizeQuery` caps `sextant_search.query` at 2 KB. Preserves the existing `"query parameter is required"` error message for the empty/missing case so `test/mcp-server.test.js` keeps passing.
   - **commands/hook-refresh.js**: caps the UserPromptSubmit prompt at 8 KB (keeps the tail) before classification + retrieval, so a runaway paste can't blow out the hook latency budget.

2. **Fragile freshness tests (test/freshness.test.js, test/freshness-gate.test.js)** — `enqueueRescan` spawns `sextant scan` via PATH lookup. On a fresh clone with no `npm link`, the spawn raised ENOENT *asynchronously after* the test that triggered it returned, which `node:test` reported as an unhandled-error failure. Each test file now installs a temp PATH shim with a no-op `sextant` script around the describes that exercise `enqueueRescan`, and removes it in the matching `after`. Tests now pass on a fresh clone without `npm link`.

3. **Docs/code drift**
   - **CLAUDE.md**: updated the deploy snippet so it states that `sextant init` wires Claude Code hooks (`SessionStart` + `UserPromptSubmit`) into `.claude/settings.json`. The longer architecture section already said this; only the quick-reference line was stale.
   - **commands/init.js**: rewrote the inverted/stale comment that claimed "CLAUDE.md correctly says init doesn't wire hooks" — `intel.init()` does wire them. The new comment accurately describes the behavior and the rare failure modes that surface in the warning path.
   - **commands/init.js**: paired with that, `ensureMcpJson` now writes `.mcp.json` via tmp+rename so a crash mid-write can't truncate the file and wipe other MCP servers.

## Test plan

- [x] `npm run test:unit` — 604 passing, 0 failing (was 1 failing before fix to preserve the existing MCP error message)
- [x] `bash scripts/test-rg.sh` — all rg integration tests pass with the `--` separator change
- [x] `bash scripts/test-refresh.sh`, `test-scoring.sh`, `test-watcher.sh`, `test-corrupt-recovery.sh` — all pass
- [x] `node --test test/freshness.test.js test/freshness-gate.test.js` — 17/17 pass (was 5 fail, 4 cancelled before the PATH shim)