### PR TITLE
feat(summary): declared-manifest cluster — Commands / Conventions / Required env [007 T1.4]

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -161,6 +161,32 @@ function entriesFromPyprojectScripts(rootAbs) {
   return candidates;
 }
 
+// package.json `scripts`: a map of name -> shell command the author declared.
+// The most authoritative answer to "how do I build / test / run this" — a
+// VERBATIM transcription (no inference, no graph), ending the "npm test? make?
+// pytest?" guess an agent otherwise makes on an unfamiliar repo.  Twin of
+// entriesFromPackageBin: reads the same already-loaded `pkg` object.  Canonical
+// lifecycle names sort first so the orientation-critical ones survive the N-cap
+// and the 2200-char clamp; ties keep declaration order.  Returns
+// [{name, command}].
+const LIFECYCLE_SCRIPTS = [
+  "dev", "start", "serve", "build", "test", "lint", "typecheck", "format", "check",
+];
+function commandsFromPackageScripts(pkg) {
+  if (!pkg || !pkg.scripts || typeof pkg.scripts !== "object" || Array.isArray(pkg.scripts)) {
+    return [];
+  }
+  const rank = (name) => {
+    const i = LIFECYCLE_SCRIPTS.indexOf(name);
+    return i === -1 ? LIFECYCLE_SCRIPTS.length : i;
+  };
+  return Object.entries(pkg.scripts)
+    .filter(([k, v]) => typeof k === "string" && k && typeof v === "string" && v.trim())
+    .map(([name, command], idx) => ({ name, command: command.trim(), idx }))
+    .sort((a, b) => rank(a.name) - rank(b.name) || a.idx - b.idx)
+    .map(({ name, command }) => ({ name, command }));
+}
+
 function mdEscapeInline(s) {
   return String(s).replace(/`/g, "\\`");
 }
@@ -374,6 +400,29 @@ function writeSummaryMarkdown(rootAbs, { db, graph }) {
     lines.push("");
   }
 
+  // "How do I run this" — verbatim from package.json `scripts`.  Placed high
+  // (right after Signals: stack → how-to-run) so it survives the 2200-char
+  // clamp, which truncates from the END.  N-capped, with long command bodies
+  // truncated since the script NAME is the primary orientation signal.  Pure
+  // package.json read, so it is a fresh-body-only fact: on a stale turn the
+  // freshness gate rebuilds a minimal body and Commands is correctly absent.
+  const commands = commandsFromPackageScripts(pkg);
+  if (commands.length) {
+    const MAX_COMMANDS = 8;
+    const MAX_CMD_CHARS = 50;
+    lines.push("### Commands");
+    for (const { name, command } of commands.slice(0, MAX_COMMANDS)) {
+      const cmd = command.length > MAX_CMD_CHARS
+        ? command.slice(0, MAX_CMD_CHARS - 1) + "…"
+        : command;
+      lines.push(`- \`${xmlEscape(mdEscapeInline(name))}\` — ${xmlEscape(mdEscapeInline(cmd))}`);
+    }
+    if (commands.length > MAX_COMMANDS) {
+      lines.push(`- …and ${commands.length - MAX_COMMANDS} more`);
+    }
+    lines.push("");
+  }
+
   if (types.length) {
     lines.push("### Module types (top)");
     for (const [t, c] of types) lines.push(`- **${xmlEscape(t)}**: ${c}`);
@@ -498,4 +547,5 @@ module.exports = {
   mdEscapeInline,
   // exported for testing
   clampChars,
+  commandsFromPackageScripts,
 };

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -72,6 +72,25 @@ function detectSignals(rootAbs) {
   if (fs.existsSync(path.join(rootAbs, "Package.swift"))) signals.push("Swift: Package.swift");
   if (fs.existsSync(path.join(rootAbs, "Gemfile"))) signals.push("Ruby: Gemfile");
 
+  // Agent / editor convention files the author hand-declared — the most
+  // authoritative orientation artifact in a repo, and one sextant otherwise
+  // ignores.  Pure presence over a fixed allowlist (no content read, no
+  // inference).  Surfaced INSIDE the Signals block (high line-order) so the
+  // 2200-char clamp — which truncates from the END — can't silently drop it.
+  // CLAUDE.md is included regardless of whether any one consumer auto-loads it:
+  // its presence is the orientation fact.
+  const conventions = [];
+  const conv = (rel, label) => {
+    if (fs.existsSync(path.join(rootAbs, rel))) conventions.push(label);
+  };
+  conv("AGENTS.md", "AGENTS.md");
+  conv("CLAUDE.md", "CLAUDE.md");
+  conv("GEMINI.md", "GEMINI.md");
+  conv(".cursorrules", ".cursorrules");
+  conv(".cursor/rules", ".cursor/rules");
+  conv(".github/copilot-instructions.md", "Copilot instructions");
+  if (conventions.length) signals.push("Conventions: " + conventions.join(", "));
+
   return { pkg, signals };
 }
 
@@ -185,6 +204,52 @@ function commandsFromPackageScripts(pkg) {
     .map(([name, command], idx) => ({ name, command: command.trim(), idx }))
     .sort((a, b) => rank(a.name) - rank(b.name) || a.idx - b.idx)
     .map(({ name, command }) => ({ name, command }));
+}
+
+// Required env vars DECLARED in a committed `.env.example`/`.sample` template —
+// the cold-start "what must be configured to run this" contract, more
+// authoritative than grepping scattered process.env.X.  KEYS ONLY: the regex
+// capture group stops at `=`, so a value/secret is structurally never read
+// (`JWT_SECRET=supersekret` → `JWT_SECRET`, never the value).  Sourced via
+// `git ls-files` so only TRACKED templates surface — an edit to a tracked file
+// moves the git-status fingerprint the freshness gate watches, so the keys can
+// never go stale-without-detection (a gitignored .env.example would be invisible
+// to that gate, the one freshness hole keys-only can't otherwise close).
+// Degrades to [] when not a git repo or no tracked template exists.
+const ENV_EXAMPLE_FILES = [".env.example", ".env.sample", ".env.template", ".env.dist"];
+function requiredEnvKeys(rootAbs) {
+  let tracked;
+  try {
+    const pathspec = ENV_EXAMPLE_FILES.map((f) => `'${f}'`).join(" ");
+    const raw = execSync(`git ls-files -z -- ${pathspec}`, {
+      cwd: rootAbs,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    tracked = raw.split("\0").map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+  if (!tracked.length) return [];
+  const keys = [];
+  const seen = new Set();
+  for (const rel of tracked) {
+    let content;
+    try {
+      content = fs.readFileSync(path.join(rootAbs, rel), "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of content.split(/\r?\n/)) {
+      // `KEY=...` or `export KEY=...` — capture ONLY the key, never the value.
+      const m = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+      if (!m) continue;
+      if (seen.has(m[1])) continue;
+      seen.add(m[1]);
+      keys.push(m[1]);
+    }
+  }
+  return keys;
 }
 
 function mdEscapeInline(s) {
@@ -423,6 +488,19 @@ function writeSummaryMarkdown(rootAbs, { db, graph }) {
     lines.push("");
   }
 
+  // "What must be configured to run this" — keys only, from a tracked
+  // .env.example template.  Operational orientation, paired with Commands; same
+  // clamp-survival placement (high line-order).  Fresh-body-only fact.
+  const envKeys = requiredEnvKeys(rootAbs);
+  if (envKeys.length) {
+    const MAX_ENV = 12;
+    const shown = envKeys.slice(0, MAX_ENV).map((k) => `\`${xmlEscape(k)}\``);
+    const more = envKeys.length > MAX_ENV ? `, …+${envKeys.length - MAX_ENV} more` : "";
+    lines.push("### Required env");
+    lines.push(`- ${shown.join(", ")}${more}`);
+    lines.push("");
+  }
+
   if (types.length) {
     lines.push("### Module types (top)");
     for (const [t, c] of types) lines.push(`- **${xmlEscape(t)}**: ${c}`);
@@ -548,4 +626,5 @@ module.exports = {
   // exported for testing
   clampChars,
   commandsFromPackageScripts,
+  requiredEnvKeys,
 };

--- a/test/summary.test.js
+++ b/test/summary.test.js
@@ -347,3 +347,87 @@ describe("summary ### Commands block (007 T1.4)", () => {
     assert.ok(!md.includes("### Commands"), "must not emit an empty Commands block");
   });
 });
+
+// ─── Convention-file presence in Signals (007 T1.4) ────────────────────────
+
+describe("detectSignals conventions (007 T1.4)", () => {
+  const { detectSignals } = require("../lib/summary");
+
+  it("flags present convention files inside Signals (FAIL-pre: no Conventions signal)", () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-conv-"));
+    try {
+      fs.writeFileSync(path.join(d, "AGENTS.md"), "x");
+      fs.writeFileSync(path.join(d, "CLAUDE.md"), "x");
+      const { signals } = detectSignals(d);
+      assert.ok(
+        signals.includes("Conventions: AGENTS.md, CLAUDE.md"),
+        `expected a Conventions signal; got ${JSON.stringify(signals)}`
+      );
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("no Conventions signal when none present (degrade quietly)", () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-conv-none-"));
+    try {
+      const { signals } = detectSignals(d);
+      assert.ok(!signals.some((s) => s.startsWith("Conventions:")), JSON.stringify(signals));
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Required env keys from a tracked .env.example (007 T1.4) ───────────────
+
+describe("requiredEnvKeys + ### Required env (007 T1.4)", () => {
+  const { execSync } = require("child_process");
+  const { requiredEnvKeys } = require("../lib/summary");
+  let tmpDir, db;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-summary-env-"));
+    fs.mkdirSync(path.join(tmpDir, ".planning", "intel"), { recursive: true });
+    execSync("git init -q", { cwd: tmpDir });
+    execSync('git config user.email "t@e.com"', { cwd: tmpDir });
+    execSync('git config user.name "T"', { cwd: tmpDir });
+    execSync("git config commit.gpgsign false", { cwd: tmpDir });
+    db = await graphMod.loadDb(tmpDir);
+  });
+  after(() => { if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it("surfaces keys from a TRACKED template, never the value; ignores an UNTRACKED template", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".env.example"),
+      "# config\nexport JWT_SECRET=supersekret\nDATABASE_URL=postgres://localhost/db\nPORT=3000\n# comment\n"
+    );
+    execSync("git add .env.example", { cwd: tmpDir });
+    execSync("git commit -q -m env", { cwd: tmpDir });
+    // An UNTRACKED template must NOT surface — the freshness-honesty guard:
+    // only tracked files move the git-status fingerprint the gate watches.
+    fs.writeFileSync(path.join(tmpDir, ".env.sample"), "UNTRACKED_KEY=zzz\n");
+
+    const keys = requiredEnvKeys(tmpDir);
+    assert.deepEqual(keys, ["JWT_SECRET", "DATABASE_URL", "PORT"]);
+    assert.ok(!keys.includes("UNTRACKED_KEY"), "untracked template must not surface");
+
+    populateGraphFromIndex(db, { "lib/core.js": { type: "js", imports: [] } });
+    const md = writeSummaryMarkdown(tmpDir, { db, graph: graphMod });
+    assert.ok(md.includes("### Required env"), `expected a Required env block; got:\n${md}`);
+    assert.ok(md.includes("`JWT_SECRET`"), md);
+    assert.ok(md.includes("`DATABASE_URL`"), md);
+    // SECURITY: the value is structurally never read.
+    assert.ok(!md.includes("supersekret"), "the secret VALUE must NEVER appear in the summary");
+  });
+
+  it("returns [] outside a git repo / with no tracked template (degrade quietly)", () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-noenv-"));
+    try {
+      fs.writeFileSync(path.join(d, ".env.example"), "X=1\n"); // present but NOT git-tracked
+      assert.deepEqual(requiredEnvKeys(d), []);
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/summary.test.js
+++ b/test/summary.test.js
@@ -266,3 +266,84 @@ describe("summary XML escaping", () => {
     }
   });
 });
+
+// ─── Commands block from package.json scripts (007 T1.4) ───────────────────
+
+describe("commandsFromPackageScripts (007 T1.4)", () => {
+  const { commandsFromPackageScripts } = require("../lib/summary");
+
+  it("returns [] for missing/malformed scripts (degrade quietly)", () => {
+    assert.deepEqual(commandsFromPackageScripts(null), []);
+    assert.deepEqual(commandsFromPackageScripts({ name: "x" }), []);
+    assert.deepEqual(commandsFromPackageScripts({ scripts: [] }), []);
+    assert.deepEqual(commandsFromPackageScripts({ scripts: { test: "" } }), []); // blank command dropped
+    assert.deepEqual(commandsFromPackageScripts({ scripts: { test: 42 } }), []); // non-string dropped
+  });
+
+  it("sorts canonical lifecycle names first, ties keep declaration order", () => {
+    const cmds = commandsFromPackageScripts({
+      scripts: { "z:custom": "z", build: "tsc", test: "node --test", "a:custom": "a", lint: "eslint ." },
+    });
+    const names = cmds.map((c) => c.name);
+    // build/test/lint are lifecycle → ahead of the custom scripts; custom scripts
+    // keep their declaration order (z:custom before a:custom).
+    assert.deepEqual(names, ["build", "test", "lint", "z:custom", "a:custom"]);
+  });
+});
+
+describe("summary ### Commands block (007 T1.4)", () => {
+  let tmpDir, db;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sextant-summary-cmds-"));
+    fs.mkdirSync(path.join(tmpDir, ".planning", "intel"), { recursive: true });
+    db = await graphMod.loadDb(tmpDir);
+  });
+  after(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("surfaces package.json scripts as a Commands block (FAIL-pre: no such block)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "demo",
+        scripts: { build: "tsc -p .", test: "node --test", lint: "eslint ." },
+      })
+    );
+    populateGraphFromIndex(db, { "lib/core.js": { type: "js", imports: [] } });
+
+    const md = writeSummaryMarkdown(tmpDir, { db, graph: graphMod });
+    // FAIL-pre: there is no "### Commands" block at all (pkg.scripts discarded).
+    assert.ok(md.includes("### Commands"), `expected a Commands block; got:\n${md}`);
+    assert.ok(md.includes("`build` — tsc -p ."), md);
+    assert.ok(md.includes("`test` — node --test"), md);
+    assert.ok(md.includes("`lint` — eslint ."), md);
+    // Placed high (right after Signals, before Module types) so it survives the clamp.
+    const cmdIdx = md.indexOf("### Commands");
+    const typesIdx = md.indexOf("### Module types");
+    if (typesIdx !== -1) assert.ok(cmdIdx < typesIdx, "Commands must precede Module types");
+  });
+
+  it("N-caps long script lists and truncates long command bodies", () => {
+    const scripts = {};
+    for (let i = 0; i < 12; i++) scripts[`task${i}`] = `echo running a fairly long command number ${i} with extra words`;
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "many", scripts }));
+    populateGraphFromIndex(db, { "lib/core.js": { type: "js", imports: [] } });
+
+    const md = writeSummaryMarkdown(tmpDir, { db, graph: graphMod });
+    assert.ok(md.includes("### Commands"));
+    assert.ok(/…and 4 more/.test(md), `expected "…and 4 more" (12 scripts, cap 8); got:\n${md}`);
+    // No single command line should be excessively long (truncated to ~50 chars).
+    const cmdLines = md.split("\n").filter((l) => /^- `task\d+` —/.test(l));
+    assert.ok(cmdLines.length === 8, `expected 8 command lines, got ${cmdLines.length}`);
+    for (const l of cmdLines) assert.ok(l.length < 80, `command line too long: ${l}`);
+  });
+
+  it("no Commands block when package.json has no scripts (degrade quietly)", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "noscripts" }));
+    populateGraphFromIndex(db, { "lib/core.js": { type: "js", imports: [] } });
+    const md = writeSummaryMarkdown(tmpDir, { db, graph: graphMod });
+    assert.ok(!md.includes("### Commands"), "must not emit an empty Commands block");
+  });
+});

--- a/todos.md
+++ b/todos.md
@@ -73,9 +73,12 @@ review-found honesty-leak cluster is on branch `feat/hookpath-honesty-and-swift-
 
 ## Active — signal expansion 007 (new target-codebase signals)
 
-- [ ] [007 T1.4 — next obvious commit] package.json `scripts` → Commands block (xs). Twin of the
-  shipped `entriesFromPackageBin`; `pkg.scripts` parsed twice and discarded. Plus AGENTS.md presence
-  (xs) and `.env.example` required-env keys (small) — the declared-manifest continuation of T1.1.
+- [x] [007 T1.4] package.json `scripts` → Commands block (xs) — SHIPPED on branch
+  `feat/manifest-commands-block` (`224f6c2`); `commandsFromPackageScripts`, `### Commands` after
+  Signals, lifecycle-first, N-cap 8, fresh-body-only. Unit 720/720, self-eval byte-identical.
+- [ ] [007 T1.4 cont.] AGENTS.md / CLAUDE.md / .cursorrules presence line (xs, inside detectSignals,
+  high line-order) + `.env.example` required-env keys (small, keys-only regex, route through
+  gitignoreFilter) — the rest of the declared-manifest continuation of T1.1.
 - [ ] [007 tier-1] Makefile Commands block, schema-file anchors, resolution-by-kind breakdown,
   public-API outline (cheap surfacing of already-graph-resident data). See doc for per-item gates.
 - [ ] [007 tier-1, SCHEMA_VERSION] Co-change "also changed with" lane in sextant_explain — supersedes

--- a/todos.md
+++ b/todos.md
@@ -76,9 +76,10 @@ review-found honesty-leak cluster is on branch `feat/hookpath-honesty-and-swift-
 - [x] [007 T1.4] package.json `scripts` → Commands block (xs) — SHIPPED on branch
   `feat/manifest-commands-block` (`224f6c2`); `commandsFromPackageScripts`, `### Commands` after
   Signals, lifecycle-first, N-cap 8, fresh-body-only. Unit 720/720, self-eval byte-identical.
-- [ ] [007 T1.4 cont.] AGENTS.md / CLAUDE.md / .cursorrules presence line (xs, inside detectSignals,
-  high line-order) + `.env.example` required-env keys (small, keys-only regex, route through
-  gitignoreFilter) — the rest of the declared-manifest continuation of T1.1.
+- [x] [007 T1.4 cont.] AGENTS.md/CLAUDE.md/.cursorrules presence (`Conventions:` in Signals) +
+  `.env.example` required-env keys (keys-only, git-ls-files tracked-gated for freshness honesty) —
+  SHIPPED (`7dfde15`) on `feat/manifest-commands-block`. Declared-manifest cluster COMPLETE. Unit
+  724/724, self-eval byte-identical, secret-value-never-leaks locked.
 - [ ] [007 tier-1] Makefile Commands block, schema-file anchors, resolution-by-kind breakdown,
   public-API outline (cheap surfacing of already-graph-resident data). See doc for per-item gates.
 - [ ] [007 tier-1, SCHEMA_VERSION] Co-change "also changed with" lane in sextant_explain — supersedes


### PR DESCRIPTION
## Summary

The declared-manifest continuation of T1.1 (007 T1.4) — three new orientation signals in the static summary, each a **verbatim read of something the author declared** (zero inference, git-tracked so they sit inside the freshness fingerprint). Closes the "how do I run / what conventions / what must I configure" axis sextant had nothing for.

Companion doc: `docs/ideas/007-signal-expansion-menu.md` (ranked this family tier-1).

## What changed (all in `lib/summary.js`)

- **`### Commands`** — `package.json scripts`, the most authoritative answer to "how do I build/test/run this." Twin of the shipped `entriesFromPackageBin` (reads the same already-loaded `pkg`, previously discarded). Lifecycle names (`dev`/`build`/`test`/`lint`…) sort first, N-cap 8, command bodies truncated to 50 chars.
- **`Conventions:`** line in `### Signals` — presence of AGENTS.md / CLAUDE.md / GEMINI.md / .cursorrules / .cursor/rules / Copilot instructions. Pure `existsSync`, emitted high in line-order so the 2200-char clamp can't drop it.
- **`### Required env`** — keys from a **git-tracked** `.env.example`/`.sample`. **Keys only**: the regex stops at `=`, so a secret value is structurally never read. Sourced via `git ls-files` so only tracked templates surface — an edit then moves the git-status fingerprint the freshness gate watches (closing the one staleness hole keys-only can't).

All three are **fresh-body-only**: on a stale turn the freshness gate's minimal body correctly omits them.

## Verification

- **Unit 724/724** (+9 across the cluster).
- **Self-eval byte-identical** (MRR 0.908) — `detectSignals`/`writeSummaryMarkdown` only; `retrieve()` and `health()` untouched.
- **Fail-pre proven** by stash for every block; **security lock**: a test asserts the secret value (`supersekret`) NEVER appears, only the key.
- Verified live on this repo: `Conventions: CLAUDE.md` + the Commands block render, `&&` correctly XML-escaped.

## Wiring

`writeSummaryMarkdown` ← `writeSummaryUnlocked` (scan/flush/schedule in `intel.js`) → `summary.md` → the hook's `injectStaticSummary` injects it. Blocks activate on the next scan that regenerates `summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)